### PR TITLE
Create the RoutePoints seeder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 services:
   - postgresql
 
-env:
-  - NODE_ENV=test
-
 install:
   - npm install
   - npm uninstall -g typescript # We should rely only on the locally installed typescript

--- a/server/src/main/migrations/20180211151800-create-route-point.ts
+++ b/server/src/main/migrations/20180211151800-create-route-point.ts
@@ -7,9 +7,9 @@ export = new NewTableMigration("RoutePoints", (types: DataTypes): DefineAttribut
       type: types.INTEGER,
    },
 
-   isReversed: {
+   subrouteIndex: {
       allowNull: false,
-      type: types.BOOLEAN,
+      type: types.INTEGER,
    },
 
    routeId: {

--- a/server/src/main/models/route-point.ts
+++ b/server/src/main/models/route-point.ts
@@ -4,14 +4,14 @@ import { ModelContainer, StandardAttributes, StandardInstance } from "../model";
 
 export interface RoutePointAttributes extends StandardAttributes {
    index?: number;
-   isReversed?: boolean;
+   subrouteIndex?: number;
    routeId?: number;
    stationId?: number;
 }
 
 export interface RoutePointInstance extends StandardInstance<RoutePointAttributes> {
    index: number;
-   isReversed: boolean;
+   subrouteIndex: number;
    routeId: number;
    stationId: number;
 
@@ -28,9 +28,9 @@ export default function (database: Sequelize, types: DataTypes): RoutePointModel
          type: types.INTEGER,
       },
 
-      isReversed: {
+      subrouteIndex: {
          allowNull: false,
-         type: types.BOOLEAN,
+         type: types.INTEGER,
       },
    });
 

--- a/server/src/main/seeders/20180213174800-route-points.ts
+++ b/server/src/main/seeders/20180213174800-route-points.ts
@@ -1,0 +1,64 @@
+import { Promise } from "bluebird";
+import * as fs from "fs";
+import * as path from "path";
+import { QueryInterface, SequelizeStatic } from "sequelize";
+import { Route, Station } from "../models";
+import { RouteInstance } from "../models/route";
+import { RoutePointAttributes } from "../models/route-point";
+import { StationInstance, } from "../models/station";
+import { PopulateTableSeeder } from "../PopulateTableSeeder";
+
+interface RouteInfo {
+   routeNumber: number;
+   vehicleType: string;
+   _routePoints: string[];
+}
+
+export = new PopulateTableSeeder<RoutePointAttributes>("RoutePoints", (): Promise<RoutePointAttributes[]> => {
+   const filePath: string = path.resolve(__dirname, "../../../resources/routes.json");
+   const resources: RouteInfo[] = JSON.parse(fs.readFileSync(filePath).toString());
+   const stationMap: { [stationNumber: string]: StationInstance } = {};
+   const routeMap: { [customRouteId: string]: RouteInstance } = {};
+
+   return Station.findAll().then((stations: StationInstance[]): Promise<RouteInstance[]> => {
+      for (const station of stations) {
+         stationMap[station.stationNumber] = station;
+      }
+      return Route.findAll();
+   }).then((routes: RouteInstance[]): RoutePointAttributes[] => {
+      for (const route of routes) {
+         routeMap[route.vehicleType + "-" + route.routeNumber] = route;
+      }
+
+      const attributes: RoutePointAttributes[] = [];
+      for (const route of resources) {
+         const routeCustomId: string = route.vehicleType + "-" + route.routeNumber;
+         const targetRoute: RouteInstance = routeMap[routeCustomId];
+         if (!targetRoute) {
+            throw new Error("Could not find route '" + routeCustomId + "'");
+         }
+         let subrouteIndex: number = 0;
+         for (const subroute of route._routePoints) {
+            const targetStationNumbers: string[] = subroute.split(",");
+
+            let routePointIndex: number = 0;
+            for (const targetStationNumber of targetStationNumbers) {
+               const targetStation: StationInstance = stationMap[targetStationNumber];
+               if (!targetStation) {
+                  throw new Error("Could not find station '" + targetStationNumber + "'");
+               }
+
+               attributes.push({
+                  index: routePointIndex,
+                  subrouteIndex,
+                  routeId: targetRoute.id,
+                  stationId: targetStation.id,
+               });
+               routePointIndex++;
+            }
+            subrouteIndex++;
+         }
+      }
+      return attributes;
+   });
+});

--- a/server/src/spec/SpecUtil.ts
+++ b/server/src/spec/SpecUtil.ts
@@ -4,6 +4,7 @@ import { AnyInstance } from "../main/model";
 export class SpecUtil {
 
    public static verifyInstance(instance: AnyInstance, attributes: any): void {
+      expect(instance).toBeTruthy();
       for (const key in attributes) {
          expect(instance.get(key)).toBe(attributes[key]);
       }

--- a/server/src/spec/Testbed.ts
+++ b/server/src/spec/Testbed.ts
@@ -1,11 +1,11 @@
 import { Promise } from "bluebird";
 import * as _ from "lodash";
 import { Model } from "sequelize";
-import { AnyInstance } from "../main/model";
+import { AnyInstance, StandardAttributes } from "../main/model";
 import { Edge, Route, RoutePoint, Station } from "../main/models";
-import { EdgeInstance } from "../main/models/edge";
-import { RouteInstance } from "../main/models/route";
-import { RoutePointInstance } from "../main/models/route-point";
+import { EdgeInstance, EdgeAttributes } from "../main/models/edge";
+import { RouteInstance, RouteAttributes } from "../main/models/route";
+import { RoutePointInstance, RoutePointAttributes } from "../main/models/route-point";
 import { StationAttributes, StationInstance } from "../main/models/station";
 
 export class Testbed {
@@ -14,25 +14,35 @@ export class Testbed {
    public static stations: StationInstance[] = [];
    public static routePoints: RoutePointInstance[] = [];
 
-   public static createRoute(): Promise<RouteInstance> {
-      return Route.create({
+   public static lastAttributes: StandardAttributes;
+
+   public static createRoute(attributes?: RouteAttributes): Promise<RouteInstance> {
+      const defaultAttributes: RouteAttributes = {
          routeNumber: 5,
          vehicleType: "bus",
-      }).then((result: RouteInstance): RouteInstance => {
+      };
+      attributes = _.defaults(attributes || {}, defaultAttributes);
+      Testbed.lastAttributes = attributes;
+
+      return Route.create(attributes).then((result: RouteInstance): RouteInstance => {
          Testbed.routes.push(result);
          return result;
       });
    }
 
    public static createEdge(station1: StationInstance,
-      station2: StationInstance): Promise<EdgeInstance> {
+      station2: StationInstance, attributes?: EdgeAttributes): Promise<EdgeInstance> {
 
-      return Edge.create({
+      const defaultAttributes: EdgeAttributes = {
          chance: 0.5,
-         fromStationId: station1.id,
-         toStationId: station2.id,
+         fromStationId: station1 ? station1.id : undefined,
+         toStationId: station2 ? station2.id : undefined,
          travelTimeMs: 1800,
-      }).then((result: EdgeInstance): EdgeInstance => {
+      };
+      attributes = _.defaults(attributes || {}, defaultAttributes);
+      Testbed.lastAttributes = attributes;
+
+      return Edge.create(attributes).then((result: EdgeInstance): EdgeInstance => {
          Testbed.edges.push(result);
          return result;
       });
@@ -47,6 +57,7 @@ export class Testbed {
          conductorAt: 1285182,
       };
       attributes = _.defaults(attributes || {}, defaultAttributes);
+      Testbed.lastAttributes = attributes;
 
       return Station.create(attributes).then((result: StationInstance): StationInstance => {
          Testbed.stations.push(result);
@@ -54,13 +65,19 @@ export class Testbed {
       });
    }
 
-   public static createRoutePoint(route: RouteInstance, station: StationInstance): Promise<RoutePointInstance> {
-      return RoutePoint.create({
+   public static createRoutePoint(route: RouteInstance, station: StationInstance,
+      attributes?: RoutePointAttributes): Promise<RoutePointInstance> {
+
+      const defaultAttributes: RoutePointAttributes = {
          index: 2,
-         isReversed: false,
+         subrouteIndex: 12,
          routeId: route.id,
          stationId: station.id,
-      }).then((result: RoutePointInstance): RoutePointInstance => {
+      };
+      attributes = _.defaults(attributes || {}, defaultAttributes);
+      Testbed.lastAttributes = attributes;
+
+      return RoutePoint.create(attributes).then((result: RoutePointInstance): RoutePointInstance => {
          Testbed.routePoints.push(result);
          return result;
       });

--- a/server/src/spec/Testbed.ts
+++ b/server/src/spec/Testbed.ts
@@ -3,9 +3,9 @@ import * as _ from "lodash";
 import { Model } from "sequelize";
 import { AnyInstance, StandardAttributes } from "../main/model";
 import { Edge, Route, RoutePoint, Station } from "../main/models";
-import { EdgeInstance, EdgeAttributes } from "../main/models/edge";
-import { RouteInstance, RouteAttributes } from "../main/models/route";
-import { RoutePointInstance, RoutePointAttributes } from "../main/models/route-point";
+import { EdgeAttributes, EdgeInstance } from "../main/models/edge";
+import { RouteAttributes, RouteInstance } from "../main/models/route";
+import { RoutePointAttributes, RoutePointInstance } from "../main/models/route-point";
 import { StationAttributes, StationInstance } from "../main/models/station";
 
 export class Testbed {

--- a/server/src/spec/models/edge.spec.ts
+++ b/server/src/spec/models/edge.spec.ts
@@ -8,16 +8,11 @@ import { Testbed } from "../Testbed";
 describe("The Edge model", (): void => {
    it("can be created and destroyed", (done: DoneFn): void => {
       let edge: EdgeInstance;
-      const edgeAttributes: EdgeAttributes = {
-         travelTimeMs: 1800,
-         fromStationId: Testbed.stations[0].id,
-         toStationId: Testbed.stations[1].id,
-         chance: 0.5,
-      };
 
-      Edge.create(edgeAttributes).then((result: EdgeInstance): Promise<void> => {
-         expect(result).toBeTruthy();
-         SpecUtil.verifyInstance(result, edgeAttributes);
+      Testbed.createEdge(Testbed.stations[0],
+         Testbed.stations[1],
+      ).then((result: EdgeInstance): Promise<void> => {
+         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
          edge = result;
          return result.destroy();
       }).then((): Promise<EdgeInstance> => {

--- a/server/src/spec/models/route-point.spec.ts
+++ b/server/src/spec/models/route-point.spec.ts
@@ -10,18 +10,12 @@ import { Testbed } from "../Testbed";
 describe("The RoutePoint model", (): void => {
    it("can be created and destroyed", (done: DoneFn): void => {
       let routePoint: RoutePointInstance;
-      const routePointAttributes: RoutePointAttributes = {
-         index: 18,
-         isReversed: false,
-         routeId: Testbed.routes[0].id,
-         stationId: Testbed.stations[0].id,
-      };
 
-      Log.DB("routePointAttributes.station.id =", routePointAttributes.stationId);
-
-      RoutePoint.create(routePointAttributes).then((result: RoutePointInstance): Promise<void> => {
-         expect(result).toBeTruthy();
-         SpecUtil.verifyInstance(result, routePointAttributes);
+      Testbed.createRoutePoint(
+         Testbed.routes[0],
+         Testbed.stations[0],
+      ).then((result: RoutePointInstance): Promise<void> => {
+         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
          routePoint = result;
          return result.destroy();
       }).then((): Promise<RoutePointInstance> => {

--- a/server/src/spec/models/route.spec.ts
+++ b/server/src/spec/models/route.spec.ts
@@ -2,18 +2,14 @@ import { Op } from "sequelize";
 import { Route } from "../../main/models";
 import { RouteAttributes, RouteInstance } from "../../main/models/route";
 import { SpecUtil } from "../SpecUtil";
+import { Testbed } from "../Testbed";
 
 describe("The Route model", (): void => {
    it("can be created and destroyed", (done: DoneFn): void => {
       let route: RouteInstance;
-      const routeAttributes: RouteAttributes = {
-         routeNumber: 1,
-         vehicleType: "bus",
-      };
 
-      Route.create(routeAttributes).then((result: RouteInstance): Promise<void> => {
-         expect(result).toBeTruthy();
-         SpecUtil.verifyInstance(result, routeAttributes);
+      Testbed.createRoute().then((result: RouteInstance): Promise<void> => {
+         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
          route = result;
          return result.destroy();
       }).then((): Promise<RouteInstance> => {


### PR DESCRIPTION
- Make all Testbed#create... methods have default attributes
- Update the RoutePoints table to have a subrouteIndex field instead of a isReversed one
- Create the RoutePoints seeder
- Update the tests accordingly