### PR TITLE
Fix the server unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,6 +3048,12 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3080,12 +3086,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/server/src/main/NewTableMigration.ts
+++ b/server/src/main/NewTableMigration.ts
@@ -41,7 +41,7 @@ export class NewTableMigration {
          type: sequelize.DATE,
       };
 
-      return queryInterface.createTable(this.tableName, attributes);
+      return Promise.resolve(queryInterface.createTable(this.tableName, attributes));
    }
 
    /**
@@ -51,6 +51,6 @@ export class NewTableMigration {
     * @param sequelize The database connection
     */
    public down(queryInterface: QueryInterface, sequelize: SequelizeStatic): Promise<void> {
-      return queryInterface.dropTable(this.tableName);
+      return Promise.resolve(queryInterface.dropTable(this.tableName));
    }
 }

--- a/server/src/main/PopulateTableSeeder.ts
+++ b/server/src/main/PopulateTableSeeder.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import { DataTypes, DefineAttributes, QueryInterface, SequelizeStatic } from "sequelize";
 import { Log } from "./Log";
 import { StandardAttributes, StandardInstance } from "./model";
@@ -60,7 +59,7 @@ export class PopulateTableSeeder<TAttributes extends StandardAttributes> {
 
    private clearTable(queryInterface: QueryInterface): Promise<void> {
       Log.DB("Clearing table '" + this.tableName + "'...");
-      return queryInterface.bulkDelete(this.tableName, {}).then((): void => {
+      return Promise.resolve(queryInterface.bulkDelete(this.tableName, {})).then((): void => {
          Log.DB("Done clearing table '" + this.tableName + "'");
       });
    }

--- a/server/src/main/conductor.util.ts
+++ b/server/src/main/conductor.util.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import * as _ from "lodash";
 import * as sequelize from "sequelize";
 import { Edge, Station } from "./models";
@@ -16,7 +15,7 @@ export interface StationWithArrivalInfo extends StationInstance {
 
 export class ConductorUtil {
 
-   public static getConductorArrivalInfo(stations: { id: number }[] | number[]):
+   public static async getConductorArrivalInfo(stations: { id: number }[] | number[]):
       Promise<{ [id: number]: StationWithArrivalInfo }> {
 
       const stationIds: number[] = [];
@@ -28,52 +27,52 @@ export class ConductorUtil {
 
       const arrivalInfo: { [stationId: number]: ConductorArrival[] } = {};
       const stationMap: { [id: number]: StationInstance } = {};
-      let edges: EdgeInstance[];
 
       const sourceStationMap: { [id: number]: StationInstance } = {};
 
-      return Promise.all([
+      const stationsAndEdges: [StationInstance[], EdgeInstance[]] = await Promise.all([
          Station.findAll({ where: { id: { [sequelize.Op.in]: stationIds } } }),
          Edge.findAll({ where: { toStationId: { [sequelize.Op.in]: stationIds } } }),
-      ]).then((result: [StationInstance[], EdgeInstance[]]): Promise<StationInstance[]> => {
-         for (const station of result[0]) {
-            stationMap[station.id] = station;
-         }
-         edges = result[1];
-         const ids: number[] = _.uniq(
-            edges.map((edge: EdgeInstance): number => edge.fromStationId));
+      ]);
+      const allStations: StationInstance[] = stationsAndEdges[0];
+      const allEdges: EdgeInstance[] = stationsAndEdges[1];
 
-         return Station.findAll({ where: { id: { [sequelize.Op.in]: ids } } });
-      }).then((result: StationInstance[]): { [id: number]: StationWithArrivalInfo } => {
-         for (const station of result) {
-            sourceStationMap[station.id] = station;
-         }
+      for (const station of allStations) {
+         stationMap[station.id] = station;
+      }
+      const ids: number[] = _.uniq(
+         allEdges.map((edge: EdgeInstance): number => edge.fromStationId));
 
-         /** The max time ago that a conductor arrival is assumed to be relevant */
-         const timeDeltaLimitMs: number = 60 * 60 * 1000;
-         // const timeDeltaLimitMs: number = Infinity;
-         const currentTime: number = new Date().getTime();
-         for (const edge of edges) {
-            const conductorAt: number =
-               parseInt(sourceStationMap[edge.fromStationId].conductorAt, 10) +
-               edge.travelTimeMs;
-            if (currentTime - conductorAt > timeDeltaLimitMs) {
-               continue;
-            }
-            arrivalInfo[edge.toStationId] = arrivalInfo[edge.toStationId] || [];
-            arrivalInfo[edge.toStationId].push({
-               arrivalChance: edge.chance,
-               arrivalTime: conductorAt,
-            });
-         }
+      const result: StationInstance[] = await Station.findAll({ where: { id: { [sequelize.Op.in]: ids } } });
 
-         const stationsWithInfo: { [id: number]: StationWithArrivalInfo } = {};
-         for (const stationId in stationMap) {
-            stationsWithInfo[stationId] = _.extend(stationMap[stationId], {
-               arrivals: arrivalInfo[stationId] || [],
-            });
+      for (const station of result) {
+         sourceStationMap[station.id] = station;
+      }
+
+      /** The max time ago that a conductor arrival is assumed to be relevant */
+      const timeDeltaLimitMs: number = 60 * 60 * 1000;
+      // const timeDeltaLimitMs: number = Infinity;
+      const currentTime: number = new Date().getTime();
+      for (const edge of allEdges) {
+         const conductorAt: number =
+            parseInt(sourceStationMap[edge.fromStationId].conductorAt, 10) +
+            edge.travelTimeMs;
+         if (currentTime - conductorAt > timeDeltaLimitMs) {
+            continue;
          }
-         return stationsWithInfo;
-      });
+         arrivalInfo[edge.toStationId] = arrivalInfo[edge.toStationId] || [];
+         arrivalInfo[edge.toStationId].push({
+            arrivalChance: edge.chance,
+            arrivalTime: conductorAt,
+         });
+      }
+
+      const stationsWithInfo: { [id: number]: StationWithArrivalInfo } = {};
+      for (const stationId in stationMap) {
+         stationsWithInfo[stationId] = _.extend(stationMap[stationId], {
+            arrivals: arrivalInfo[stationId] || [],
+         });
+      }
+      return stationsWithInfo;
    }
 }

--- a/server/src/main/controllers/stations.ts
+++ b/server/src/main/controllers/stations.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import { Request, Response } from "express";
 import * as _ from "lodash";
 import * as sequelize from "sequelize";
@@ -56,7 +55,7 @@ interface StationResponse {
 
 const maxDistance: number = 500;
 
-router.get("/", extractParams, (req: StationRequest, res: Response): any => {
+router.get("/", extractParams, async (req: StationRequest, res: Response): Promise<any> => {
    const longtitude: number = parseFloat(req.queryParams.longtitude || "");
    const latitude: number = parseFloat(req.queryParams.latitude || "");
    if (isNaN(longtitude)) {
@@ -69,134 +68,127 @@ router.get("/", extractParams, (req: StationRequest, res: Response): any => {
    let responses: StationResponse[] = [];
 
    type BulkResult1 = [{ [id: number]: StationWithArrivalInfo }, RoutePointInstance[]];
+
+   const allStations: StationInstance[] = await Station.findAll();
+   for (const station of allStations) {
+      responses.push({
+         id: station.id,
+         name: station.name,
+         distance: MathUtil.getDistanceInMeters(station, { longtitude, latitude }),
+         arrivals: [],
+         routes: [],
+      });
+   }
+   responses = responses.filter((station: StationResponse): boolean =>
+      station.distance < maxDistance);
+   responses.sort((s1: any, s2: any): number => s1.distance - s2.distance);
+
+   const stationIds: number[] = responses
+      .map((station: StationResponse): number => station.id);
+
+   const bulkResult1: BulkResult1 = await Promise.all([
+      ConductorUtil.getConductorArrivalInfo(responses),
+      RoutePoint.findAll({ where: { stationId: { [sequelize.Op.in]: stationIds } } }),
+   ]);
+
+   for (const station of responses) {
+      station.arrivals = bulkResult1[0][station.id].arrivals;
+   }
+   const routeIds: number[] = _.uniq(bulkResult1[1]
+      .map((routePoint: RoutePointInstance): number => routePoint.routeId));
+
    type BulkResult2 = [RoutePointInstance[], RouteInstance[]];
 
-   let routePoints: RoutePointInstance[];
+   const bulkResult2: BulkResult2 = await Promise.all([
+      RoutePoint.findAll({ where: { routeId: { [sequelize.Op.in]: routeIds } } }),
+      Route.findAll({ where: { id: { [sequelize.Op.in]: routeIds } } }),
+   ]);
+
+   const routePoints: RoutePointInstance[] = bulkResult2[0];
+
    const routeMap: { [id: number]: RouteInstance } = {};
+   for (const route of bulkResult2[1]) {
+      routeMap[route.id] = route;
+   }
 
-   return Station.findAll().then((result: StationInstance[]): Promise<BulkResult1> => {
+   const routePointMap: { [stationId: number]: RoutePointInstance[] } = {};
+   for (const routePoint of routePoints) {
+      routePointMap[routePoint.stationId] = routePointMap[routePoint.stationId] || [];
+      routePointMap[routePoint.stationId].push(routePoint);
+   }
 
-      for (const station of result) {
-         responses.push({
-            id: station.id,
-            name: station.name,
-            distance: MathUtil.getDistanceInMeters(station, { longtitude, latitude }),
-            arrivals: [],
-            routes: [],
+   routePoints.sort((rp1: RoutePointInstance, rp2: RoutePointInstance): number => {
+      if (rp1.routeId !== rp2.routeId) {
+         return rp1.routeId - rp2.routeId;
+      }
+      if (rp1.subrouteIndex !== rp2.subrouteIndex) {
+         return rp1.subrouteIndex - rp2.subrouteIndex;
+      }
+      return rp1.index - rp2.index;
+   });
+   const routePointIndices: { [id: number]: number } = {};
+   for (let i: number = 0; i < routePoints.length; i++) {
+      routePointIndices[routePoints[i].id] = i;
+   }
+
+   const stationsToGetNamesOf: number[] = [];
+
+   for (const station of responses) {
+      const stationRoutePoints: RoutePointInstance[] = routePointMap[station.id] || [];
+      for (const routePoint of stationRoutePoints) {
+
+         const index: number = routePointIndices[routePoint.id];
+         const firstIndex: number = index - routePoints[index].index;
+         let lastIndex: number = index;
+         while (lastIndex < routePoints.length - 1
+            && routePoints[lastIndex + 1].index === routePoints[lastIndex].index + 1) {
+            lastIndex++;
+         }
+         stationsToGetNamesOf.push(routePoints[firstIndex].stationId);
+         stationsToGetNamesOf.push(routePoints[lastIndex].stationId);
+
+         const correspondingRoute: RouteInstance = routeMap[routePoint.routeId];
+
+         station.routes.push({
+            firstStationId: routePoints[firstIndex].stationId,
+            firstStationName: "",
+            lastStationId: routePoints[lastIndex].stationId,
+            lastStationName: "",
+            routeNumber: correspondingRoute.routeNumber,
+            routeType: correspondingRoute.vehicleType,
          });
       }
-      responses = responses.filter((station: StationResponse): boolean =>
-         station.distance < maxDistance);
-      responses.sort((s1: any, s2: any): number => s1.distance - s2.distance);
+   }
 
-      const stationIds: number[] = responses
-         .map((station: StationResponse): number => station.id);
-
-      return Promise.all([
-         ConductorUtil.getConductorArrivalInfo(responses),
-         RoutePoint.findAll({ where: { stationId: { [sequelize.Op.in]: stationIds } } }),
-      ]);
-   }).then((result: BulkResult1): Promise<BulkResult2> => {
-      for (const station of responses) {
-         station.arrivals = result[0][station.id].arrivals;
-      }
-      const routeIds: number[] = _.uniq(result[1]
-         .map((routePoint: RoutePointInstance): number => routePoint.routeId));
-      return Promise.all([
-         RoutePoint.findAll({ where: { routeId: { [sequelize.Op.in]: routeIds } } }),
-         Route.findAll({ where: { id: { [sequelize.Op.in]: routeIds } } }),
-      ]);
-   }).then((result: BulkResult2): Promise<StationInstance[]> => {
-      routePoints = result[0];
-      for (const route of result[1]) {
-         routeMap[route.id] = route;
-      }
-      const routePointMap: { [stationId: number]: RoutePointInstance[] } = {};
-      for (const routePoint of result[0]) {
-         routePointMap[routePoint.stationId] = routePointMap[routePoint.stationId] || [];
-         routePointMap[routePoint.stationId].push(routePoint);
-      }
-
-      result[0].sort((rp1: RoutePointInstance, rp2: RoutePointInstance): number => {
-         if (rp1.routeId !== rp2.routeId) {
-            return rp1.routeId - rp2.routeId;
-         }
-         if (rp1.subrouteIndex !== rp2.subrouteIndex) {
-            return rp1.subrouteIndex - rp2.subrouteIndex;
-         }
-         return rp1.index - rp2.index;
-      });
-      const routePointIndices: { [id: number]: number } = {};
-      for (let i: number = 0; i < result[0].length; i++) {
-         routePointIndices[result[0][i].id] = i;
-      }
-
-      const stationsToGetNamesOf: number[] = [];
-
-      for (const station of responses) {
-         const stationRoutePoints: RoutePointInstance[] = routePointMap[station.id] || [];
-         for (const routePoint of stationRoutePoints) {
-
-            const index: number = routePointIndices[routePoint.id];
-            const firstIndex: number = index - result[0][index].index;
-            let lastIndex: number = index;
-            while (lastIndex < result[0].length - 1
-               && result[0][lastIndex + 1].index === result[0][lastIndex].index + 1) {
-               lastIndex++;
-            }
-            stationsToGetNamesOf.push(result[0][firstIndex].stationId);
-            stationsToGetNamesOf.push(result[0][lastIndex].stationId);
-
-            const correspondingRoute: RouteInstance = routeMap[routePoint.routeId];
-
-            station.routes.push({
-               firstStationId: result[0][firstIndex].stationId,
-               firstStationName: "",
-               lastStationId: result[0][lastIndex].stationId,
-               lastStationName: "",
-               routeNumber: correspondingRoute.routeNumber,
-               routeType: correspondingRoute.vehicleType,
-            });
-         }
-      }
-
-      return Station.findAll({
-         where: { id: { [sequelize.Op.in]: _.uniq(stationsToGetNamesOf) } },
-      });
-   }).then((result: StationInstance[]): any => {
-      const stationMap: { [id: number]: StationInstance } = {};
-      for (const station of result) {
-         stationMap[station.id] = station;
-      }
-      for (const station of responses) {
-         for (const routeInfo of station.routes) {
-            routeInfo.firstStationName = stationMap[routeInfo.firstStationId].name;
-            routeInfo.lastStationName = stationMap[routeInfo.lastStationId].name;
-         }
-      }
-
-      return res.status(200).send(responses);
+   const result: StationInstance[] = await Station.findAll({
+      where: { id: { [sequelize.Op.in]: _.uniq(stationsToGetNamesOf) } },
    });
+
+   const stationMap: { [id: number]: StationInstance } = {};
+   for (const station of result) {
+      stationMap[station.id] = station;
+   }
+   for (const station of responses) {
+      for (const routeInfo of station.routes) {
+         routeInfo.firstStationName = stationMap[routeInfo.firstStationId].name;
+         routeInfo.lastStationName = stationMap[routeInfo.lastStationId].name;
+      }
+   }
+
+   return res.status(200).send(responses);
 });
 
-router.get("/:id", extractParams, (req: StationRequest, res: Response): Promise<any> => {
-   return Station.findById(req.newParams.id)
-      .then((station: StationInstance | null): any => {
-         return res.status(200).send(station);
-      });
+router.get("/:id", extractParams, async (req: StationRequest, res: Response): Promise<any> => {
+   const station: StationInstance | null = await Station.findById(req.newParams.id);
+   return res.status(200).send(station);
 });
 
-router.put("/:id", extractParams, (req: StationRequest, res: Response): Promise<any> => {
-   return Station.update(
+router.put("/:id", extractParams, async (req: StationRequest, res: Response): Promise<any> => {
+   const station: [number, StationInstance[]] = await Station.update(
       { conductorAt: new Date().getTime() },
       { where: { id: req.newParams.id } },
-   ).then((station: [number, StationInstance[]]): any => {
-      if (!station[0]) {
-         return res.sendStatus(404);
-      }
-
-      return res.status(200).send(station);
-   });
+   );
+   return station[0] ? res.status(200).send(station) : res.sendStatus(404);
 });
 
 export default router;

--- a/server/src/main/seeders/20180213010800-routes.ts
+++ b/server/src/main/seeders/20180213010800-routes.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import * as fs from "fs";
 import * as path from "path";
 import { QueryInterface, SequelizeStatic } from "sequelize";

--- a/server/src/main/seeders/20180213170600-stations.ts
+++ b/server/src/main/seeders/20180213170600-stations.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import * as fs from "fs";
 import * as path from "path";
 import { QueryInterface, SequelizeStatic } from "sequelize";

--- a/server/src/main/seeders/20180213174800-route-points.ts
+++ b/server/src/main/seeders/20180213174800-route-points.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import * as fs from "fs";
 import * as path from "path";
 import { QueryInterface, SequelizeStatic } from "sequelize";
@@ -14,53 +13,51 @@ interface RouteInfo {
    _routePoints: string[];
 }
 
-export = new PopulateTableSeeder<RoutePointAttributes>("RoutePoints", (): Promise<RoutePointAttributes[]> => {
+export = new PopulateTableSeeder<RoutePointAttributes>("RoutePoints", async (): Promise<RoutePointAttributes[]> => {
    const filePath: string = path.resolve(__dirname, "../../../resources/routes.json");
    const resources: RouteInfo[] = JSON.parse(fs.readFileSync(filePath).toString());
 
-   return Promise.all([
-      Station.findAll(),
-      Route.findAll(),
-   ]).then((result: [StationInstance[], RouteInstance[]]): RoutePointAttributes[] => {
-      const stationMap: { [stationNumber: string]: StationInstance } = {};
-      for (const station of result[0]) {
-         stationMap[station.stationNumber] = station;
+   const result: [StationInstance[], RouteInstance[]] =
+      await Promise.all([Station.findAll(), Route.findAll()]);
+
+   const stationMap: { [stationNumber: string]: StationInstance } = {};
+   for (const station of result[0]) {
+      stationMap[station.stationNumber] = station;
+   }
+
+   const routeMap: { [customRouteId: string]: RouteInstance } = {};
+   for (const route of result[1]) {
+      routeMap[route.vehicleType + ":" + route.routeNumber] = route;
+   }
+
+   const attributes: RoutePointAttributes[] = [];
+   for (const route of resources) {
+      const routeCustomId: string = route.vehicleType + ":" + route.routeNumber;
+      const targetRoute: RouteInstance = routeMap[routeCustomId];
+      if (!targetRoute) {
+         throw new Error("Could not find route '" + routeCustomId + "'");
       }
+      let subrouteIndex: number = 0;
+      for (const subroute of route._routePoints) {
+         const targetStationNumbers: string[] = subroute.split(",");
 
-      const routeMap: { [customRouteId: string]: RouteInstance } = {};
-      for (const route of result[1]) {
-         routeMap[route.vehicleType + ":" + route.routeNumber] = route;
-      }
-
-      const attributes: RoutePointAttributes[] = [];
-      for (const route of resources) {
-         const routeCustomId: string = route.vehicleType + ":" + route.routeNumber;
-         const targetRoute: RouteInstance = routeMap[routeCustomId];
-         if (!targetRoute) {
-            throw new Error("Could not find route '" + routeCustomId + "'");
-         }
-         let subrouteIndex: number = 0;
-         for (const subroute of route._routePoints) {
-            const targetStationNumbers: string[] = subroute.split(",");
-
-            let routePointIndex: number = 0;
-            for (const targetStationNumber of targetStationNumbers) {
-               const targetStation: StationInstance = stationMap[targetStationNumber];
-               if (!targetStation) {
-                  throw new Error("Could not find station '" + targetStationNumber + "'");
-               }
-
-               attributes.push({
-                  index: routePointIndex,
-                  subrouteIndex,
-                  routeId: targetRoute.id,
-                  stationId: targetStation.id,
-               });
-               routePointIndex++;
+         let routePointIndex: number = 0;
+         for (const targetStationNumber of targetStationNumbers) {
+            const targetStation: StationInstance = stationMap[targetStationNumber];
+            if (!targetStation) {
+               throw new Error("Could not find station '" + targetStationNumber + "'");
             }
-            subrouteIndex++;
+
+            attributes.push({
+               index: routePointIndex,
+               subrouteIndex,
+               routeId: targetRoute.id,
+               stationId: targetStation.id,
+            });
+            routePointIndex++;
          }
+         subrouteIndex++;
       }
-      return attributes;
-   });
+   }
+   return attributes;
 });

--- a/server/src/main/seeders/20180213223000-edges.ts
+++ b/server/src/main/seeders/20180213223000-edges.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import * as fs from "fs";
 import * as path from "path";
 import { QueryInterface, SequelizeStatic } from "sequelize";
@@ -59,128 +58,126 @@ function normalizeEdges(edges: DefinedEdgeAttributes[]): void {
    }
 }
 
-export = new PopulateTableSeeder<EdgeAttributes>("Edges", (): Promise<EdgeAttributes[]> => {
-   return Promise.all([
-      Station.findAll(),
-      RoutePoint.findAll(),
-   ]).then((result: [StationInstance[], RoutePointInstance[]]): EdgeAttributes[] => {
-      let attributes: DefinedEdgeAttributes[] = [];
-      const stationMap: { [id: number]: StationInstance } = {};
-      const originalEdges: { [id: number]: DefinedEdgeAttributes[] } = {};
-      const additionalEdges: { [id: number]: DefinedEdgeAttributes[] } = {};
+export = new PopulateTableSeeder<EdgeAttributes>("Edges", async (): Promise<EdgeAttributes[]> => {
+   const result: [StationInstance[], RoutePointInstance[]] =
+      await Promise.all([Station.findAll(), RoutePoint.findAll()]);
 
-      for (const station of result[0]) {
-         stationMap[station.id] = station;
-         originalEdges[station.id] = [];
-         additionalEdges[station.id] = [];
+   let attributes: DefinedEdgeAttributes[] = [];
+   const stationMap: { [id: number]: StationInstance } = {};
+   const originalEdges: { [id: number]: DefinedEdgeAttributes[] } = {};
+   const additionalEdges: { [id: number]: DefinedEdgeAttributes[] } = {};
+
+   for (const station of result[0]) {
+      stationMap[station.id] = station;
+      originalEdges[station.id] = [];
+      additionalEdges[station.id] = [];
+   }
+
+   const routePoints: RoutePointInstance[] = result[1];
+   routePoints.sort((routePoint1: RoutePointInstance, routePoint2: RoutePointInstance): number => {
+      if (routePoint1.routeId !== routePoint2.routeId) {
+         return routePoint1.routeId - routePoint2.routeId;
       }
-
-      const routePoints: RoutePointInstance[] = result[1];
-      routePoints.sort((routePoint1: RoutePointInstance, routePoint2: RoutePointInstance): number => {
-         if (routePoint1.routeId !== routePoint2.routeId) {
-            return routePoint1.routeId - routePoint2.routeId;
-         }
-         if (routePoint1.subrouteIndex !== routePoint2.subrouteIndex) {
-            return routePoint1.subrouteIndex - routePoint2.subrouteIndex;
-         }
-         return routePoint1.index - routePoint2.index;
-      });
-
-      for (let i: number = 1; i < routePoints.length; i++) {
-         if (routePoints[i - 1].routeId === routePoints[i].routeId
-            && routePoints[i - 1].subrouteIndex === routePoints[i].subrouteIndex) {
-
-            const fromStation: StationInstance = stationMap[routePoints[i - 1].stationId];
-            const toStation: StationInstance = stationMap[routePoints[i].stationId];
-            const newEdge: DefinedEdgeAttributes = {
-               fromStationId: fromStation.id,
-               toStationId: toStation.id,
-               travelTimeMs: Math.floor(
-                  MathUtil.getDistanceInMeters(fromStation, toStation) / busSpeed * 1000),
-               chance: busCoefficient,
-            };
-            originalEdges[newEdge.fromStationId].push(newEdge);
-         }
+      if (routePoint1.subrouteIndex !== routePoint2.subrouteIndex) {
+         return routePoint1.subrouteIndex - routePoint2.subrouteIndex;
       }
-      for (const stationId in stationMap) {
-         originalEdges[stationId] = mergeEdges(originalEdges[stationId]);
-         attributes = attributes.concat(originalEdges[stationId]);
-      }
-      Log.DB("Edges: " + attributes.length);
+      return routePoint1.index - routePoint2.index;
+   });
 
-      Log.DB("Human walking edges...");
-      const stations: StationInstance[] = result[0];
-      let allPairs: number = 0;
-      let closeEnoughPairs: number = 0;
-      stations.sort((station1: StationInstance, station2: StationInstance): number => {
-         return station1.latitude - station2.latitude;
-      });
-      for (let i: number = 0; i < stations.length; i++) {
-         for (let j: number = i + 1; j < stations.length && j < (i + stations.length / 10); j++) {
-            const station1: StationInstance = stations[i];
-            const station2: StationInstance = stations[j];
-            allPairs++;
-            const distance: number = MathUtil.getDistanceInMeters(station1, station2);
-            const coefficient: number = getWalkCoefficient(distance);
-            if (coefficient < 0.1) {
+   for (let i: number = 1; i < routePoints.length; i++) {
+      if (routePoints[i - 1].routeId === routePoints[i].routeId
+         && routePoints[i - 1].subrouteIndex === routePoints[i].subrouteIndex) {
+
+         const fromStation: StationInstance = stationMap[routePoints[i - 1].stationId];
+         const toStation: StationInstance = stationMap[routePoints[i].stationId];
+         const newEdge: DefinedEdgeAttributes = {
+            fromStationId: fromStation.id,
+            toStationId: toStation.id,
+            travelTimeMs: Math.floor(
+               MathUtil.getDistanceInMeters(fromStation, toStation) / busSpeed * 1000),
+            chance: busCoefficient,
+         };
+         originalEdges[newEdge.fromStationId].push(newEdge);
+      }
+   }
+   for (const stationId in stationMap) {
+      originalEdges[stationId] = mergeEdges(originalEdges[stationId]);
+      attributes = attributes.concat(originalEdges[stationId]);
+   }
+   Log.DB("Edges: " + attributes.length);
+
+   Log.DB("Human walking edges...");
+   const stations: StationInstance[] = result[0];
+   let allPairs: number = 0;
+   let closeEnoughPairs: number = 0;
+   stations.sort((station1: StationInstance, station2: StationInstance): number => {
+      return station1.latitude - station2.latitude;
+   });
+   for (let i: number = 0; i < stations.length; i++) {
+      for (let j: number = i + 1; j < stations.length && j < (i + stations.length / 10); j++) {
+         const station1: StationInstance = stations[i];
+         const station2: StationInstance = stations[j];
+         allPairs++;
+         const distance: number = MathUtil.getDistanceInMeters(station1, station2);
+         const coefficient: number = getWalkCoefficient(distance);
+         if (coefficient < 0.1) {
+            continue;
+         }
+         closeEnoughPairs++;
+         const travelTimeMs: number = distance / humanSpeed * 1000;
+         const edge1: DefinedEdgeAttributes = {
+            fromStationId: station1.id,
+            toStationId: station2.id,
+            chance: coefficient,
+            travelTimeMs,
+         };
+         const edge2: DefinedEdgeAttributes = {
+            fromStationId: station2.id,
+            toStationId: station1.id,
+            chance: coefficient,
+            travelTimeMs,
+         };
+         originalEdges[station1.id].push(edge1);
+         originalEdges[station2.id].push(edge2);
+         attributes.push(edge1, edge2);
+      }
+   }
+   Log.DB("Human walking edge pairs: " + closeEnoughPairs + "/" + allPairs);
+
+   let lastPass: DefinedEdgeAttributes[] = [];
+   let currentPass: DefinedEdgeAttributes[] = [];
+
+   for (const stationId in stationMap) {
+      normalizeEdges(originalEdges[stationId]);
+      for (const edge of originalEdges[stationId]) {
+         currentPass.push(edge);
+      }
+   }
+
+   Log.DB("Edges: " + attributes.length);
+
+   while (!!currentPass.length && attributes.length < 150000) {
+      lastPass = currentPass;
+      currentPass = [];
+      for (const firstEdge of lastPass) {
+         for (const secondEdge of originalEdges[firstEdge.toStationId]) {
+            const newChance: number = firstEdge.chance * secondEdge.chance;
+            if (newChance < 0.05) {
                continue;
             }
-            closeEnoughPairs++;
-            const travelTimeMs: number = distance / humanSpeed * 1000;
-            const edge1: DefinedEdgeAttributes = {
-               fromStationId: station1.id,
-               toStationId: station2.id,
-               chance: coefficient,
-               travelTimeMs,
+            const newEdge: DefinedEdgeAttributes = {
+               fromStationId: firstEdge.fromStationId,
+               toStationId: secondEdge.toStationId,
+               chance: firstEdge.chance * secondEdge.chance,
+               travelTimeMs: firstEdge.travelTimeMs + secondEdge.travelTimeMs,
             };
-            const edge2: DefinedEdgeAttributes = {
-               fromStationId: station2.id,
-               toStationId: station1.id,
-               chance: coefficient,
-               travelTimeMs,
-            };
-            originalEdges[station1.id].push(edge1);
-            originalEdges[station2.id].push(edge2);
-            attributes.push(edge1, edge2);
+            additionalEdges[newEdge.fromStationId].push(newEdge);
+            attributes.push(newEdge);
+            currentPass.push(newEdge);
          }
       }
-      Log.DB("Human walking edge pairs: " + closeEnoughPairs + "/" + allPairs);
-
-      let lastPass: DefinedEdgeAttributes[] = [];
-      let currentPass: DefinedEdgeAttributes[] = [];
-
-      for (const stationId in stationMap) {
-         normalizeEdges(originalEdges[stationId]);
-         for (const edge of originalEdges[stationId]) {
-            currentPass.push(edge);
-         }
-      }
-
       Log.DB("Edges: " + attributes.length);
+   }
 
-      while (!!currentPass.length && attributes.length < 150000) {
-         lastPass = currentPass;
-         currentPass = [];
-         for (const firstEdge of lastPass) {
-            for (const secondEdge of originalEdges[firstEdge.toStationId]) {
-               const newChance: number = firstEdge.chance * secondEdge.chance;
-               if (newChance < 0.05) {
-                  continue;
-               }
-               const newEdge: DefinedEdgeAttributes = {
-                  fromStationId: firstEdge.fromStationId,
-                  toStationId: secondEdge.toStationId,
-                  chance: firstEdge.chance * secondEdge.chance,
-                  travelTimeMs: firstEdge.travelTimeMs + secondEdge.travelTimeMs,
-               };
-               additionalEdges[newEdge.fromStationId].push(newEdge);
-               attributes.push(newEdge);
-               currentPass.push(newEdge);
-            }
-         }
-         Log.DB("Edges: " + attributes.length);
-      }
-
-      return attributes;
-   });
+   return attributes;
 });

--- a/server/src/spec/SpecUtil.ts
+++ b/server/src/spec/SpecUtil.ts
@@ -1,4 +1,3 @@
-import { Promise } from "bluebird";
 import { AnyInstance } from "../main/model";
 
 export class SpecUtil {
@@ -10,16 +9,7 @@ export class SpecUtil {
       }
    }
 
-   public static destroy(...instances: AnyInstance[]): Promise<void> {
-      return this.destroyInternal(instances, 0);
-   }
-
-   private static destroyInternal(instances: AnyInstance[],
-      index: number): Promise<void> {
-
-      return index >= instances.length
-         ? Promise.resolve()
-         : instances[index].destroy()
-            .then((): Promise<void> => this.destroyInternal(instances, index + 1));
+   public static destroy(...instances: AnyInstance[]): Promise<void[]> {
+      return Promise.all(instances.map((instance: AnyInstance) => instance.destroy()));
    }
 }

--- a/server/src/spec/Testbed.ts
+++ b/server/src/spec/Testbed.ts
@@ -1,6 +1,4 @@
-import { Promise } from "bluebird";
 import * as _ from "lodash";
-import { Model } from "sequelize";
 import { AnyInstance, StandardAttributes } from "../main/model";
 import { Edge, Route, RoutePoint, Station } from "../main/models";
 import { EdgeAttributes, EdgeInstance } from "../main/models/edge";
@@ -16,7 +14,7 @@ export class Testbed {
 
    public static lastAttributes: StandardAttributes;
 
-   public static createRoute(attributes?: RouteAttributes): Promise<RouteInstance> {
+   public static async createRoute(attributes?: RouteAttributes): Promise<RouteInstance> {
       const defaultAttributes: RouteAttributes = {
          routeNumber: "44-Б",
          vehicleType: "bus",
@@ -24,13 +22,12 @@ export class Testbed {
       attributes = _.defaults(attributes || {}, defaultAttributes);
       Testbed.lastAttributes = attributes;
 
-      return Route.create(attributes).then((result: RouteInstance): RouteInstance => {
-         Testbed.routes.push(result);
-         return result;
-      });
+      const result: RouteInstance = await Route.create(attributes);
+      Testbed.routes.push(result);
+      return result;
    }
 
-   public static createEdge(station1: StationInstance,
+   public static async createEdge(station1: StationInstance,
       station2: StationInstance, attributes?: EdgeAttributes): Promise<EdgeInstance> {
 
       const defaultAttributes: EdgeAttributes = {
@@ -42,13 +39,12 @@ export class Testbed {
       attributes = _.defaults(attributes || {}, defaultAttributes);
       Testbed.lastAttributes = attributes;
 
-      return Edge.create(attributes).then((result: EdgeInstance): EdgeInstance => {
-         Testbed.edges.push(result);
-         return result;
-      });
+      const result: EdgeInstance = await Edge.create(attributes);
+      Testbed.edges.push(result);
+      return result;
    }
 
-   public static createStation(attributes?: StationAttributes): Promise<StationInstance> {
+   public static async createStation(attributes?: StationAttributes): Promise<StationInstance> {
       const defaultAttributes: StationAttributes = {
          name: "some-station",
          stationNumber: "0" + Math.floor(Math.random() * 1000000).toString(),
@@ -65,7 +61,7 @@ export class Testbed {
       });
    }
 
-   public static createRoutePoint(route: RouteInstance, station: StationInstance,
+   public static async createRoutePoint(route: RouteInstance, station: StationInstance,
       attributes?: RoutePointAttributes): Promise<RoutePointInstance> {
 
       const defaultAttributes: RoutePointAttributes = {
@@ -77,31 +73,24 @@ export class Testbed {
       attributes = _.defaults(attributes || {}, defaultAttributes);
       Testbed.lastAttributes = attributes;
 
-      return RoutePoint.create(attributes).then((result: RoutePointInstance): RoutePointInstance => {
-         Testbed.routePoints.push(result);
-         return result;
-      });
+      const result: RoutePointInstance = await RoutePoint.create(attributes);
+      Testbed.routePoints.push(result);
+      return result;
    }
 
-   public static destroyAll(): Promise<void> {
-      const result: Promise<void> = Promise.all([
+   public static async destroyAll(): Promise<void> {
+      await Promise.all([
          Testbed.destroy(Testbed.edges),
          Testbed.destroy(Testbed.routes),
          Testbed.destroy(Testbed.stations),
-      ]).then((): void => { return; });
+      ]);
 
       Testbed.edges = [];
       Testbed.routes = [];
       Testbed.stations = [];
-
-      return result;
    }
 
-   private static destroy(instances: AnyInstance[]): Promise<void> {
-      const promises: Array<Promise<void>> = [];
-      for (const instance of instances) {
-         promises.push(instance.destroy());
-      }
-      return Promise.all(promises).then((): void => { return; });
+   private static destroy(instances: AnyInstance[]): Promise<void[]> {
+      return Promise.all(instances.map((instance: AnyInstance) => instance.destroy()));
    }
 }

--- a/server/src/spec/helpers/setup.ts
+++ b/server/src/spec/helpers/setup.ts
@@ -1,22 +1,19 @@
 process.env.NODE_ENV = "test";
 
-import { Promise } from "bluebird";
-import { Log } from "../../main/Log";
 import { Testbed } from "../Testbed";
 
-beforeEach((done: DoneFn): void => {
-   Promise.all([
+beforeEach(async () => {
+   await Promise.all([
       Testbed.createRoute(),
       Testbed.createStation(),
       Testbed.createStation(),
-   ]).then((): Promise<any> => {
-      expect(Testbed.stations.length).toBe(2);
-      expect(Testbed.routes.length).toBe(1);
-      return Promise.all([
-         Testbed.createEdge(Testbed.stations[0], Testbed.stations[1]),
-         Testbed.createRoutePoint(Testbed.routes[0], Testbed.stations[0]),
-      ]);
-   }).then(done).catch(done);
+   ]);
+   expect(Testbed.stations.length).toBe(2);
+   expect(Testbed.routes.length).toBe(1);
+   await Promise.all([
+      Testbed.createEdge(Testbed.stations[0], Testbed.stations[1]),
+      Testbed.createRoutePoint(Testbed.routes[0], Testbed.stations[0]),
+   ]);
 });
 
 afterEach((done: DoneFn): void => {

--- a/server/src/spec/models/edge.spec.ts
+++ b/server/src/spec/models/edge.spec.ts
@@ -1,24 +1,16 @@
-import { Op } from "sequelize";
-import { Edge, Station } from "../../main/models";
-import { EdgeAttributes, EdgeInstance } from "../../main/models/edge";
-import { StationAttributes, StationInstance } from "../../main/models/station";
+import { Edge } from "../../main/models";
+import { EdgeInstance } from "../../main/models/edge";
 import { SpecUtil } from "../SpecUtil";
 import { Testbed } from "../Testbed";
 
 describe("The Edge model", (): void => {
-   it("can be created and destroyed", (done: DoneFn): void => {
-      let edge: EdgeInstance;
+   it("can be created and destroyed", async () => {
+      const edge: EdgeInstance = await
+         Testbed.createEdge(Testbed.stations[0], Testbed.stations[1]);
 
-      Testbed.createEdge(Testbed.stations[0],
-         Testbed.stations[1],
-      ).then((result: EdgeInstance): Promise<void> => {
-         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
-         edge = result;
-         return result.destroy();
-      }).then((): Promise<EdgeInstance> => {
-         return Edge.findById(edge.id);
-      }).then((result: EdgeInstance): void => {
-         expect(result).toBeFalsy();
-      }).then(done).catch(done);
+      SpecUtil.verifyInstance(edge, Testbed.lastAttributes);
+      await edge.destroy();
+
+      expect(await Edge.findById(edge.id)).toBeFalsy();
    });
 });

--- a/server/src/spec/models/route-point.spec.ts
+++ b/server/src/spec/models/route-point.spec.ts
@@ -1,27 +1,16 @@
-import { Op } from "sequelize";
-import { Log } from "../../main/Log";
-import { Route, RoutePoint, Station } from "../../main/models";
-import { RouteAttributes, RouteInstance } from "../../main/models/route";
-import { RoutePointAttributes, RoutePointInstance } from "../../main/models/route-point";
-import { StationAttributes, StationInstance } from "../../main/models/station";
+import { RoutePoint } from "../../main/models";
+import { RoutePointInstance } from "../../main/models/route-point";
 import { SpecUtil } from "../SpecUtil";
 import { Testbed } from "../Testbed";
 
 describe("The RoutePoint model", (): void => {
-   it("can be created and destroyed", (done: DoneFn): void => {
-      let routePoint: RoutePointInstance;
+   it("can be created and destroyed", async () => {
+      const routePoint: RoutePointInstance = await
+         Testbed.createRoutePoint(Testbed.routes[0], Testbed.stations[0]);
 
-      Testbed.createRoutePoint(
-         Testbed.routes[0],
-         Testbed.stations[0],
-      ).then((result: RoutePointInstance): Promise<void> => {
-         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
-         routePoint = result;
-         return result.destroy();
-      }).then((): Promise<RoutePointInstance> => {
-         return RoutePoint.findById(routePoint.id);
-      }).then((result: RoutePointInstance): void => {
-         expect(result).toBeFalsy();
-      }).then(done).catch(done);
+      SpecUtil.verifyInstance(routePoint, Testbed.lastAttributes);
+      await routePoint.destroy();
+
+      expect(await RoutePoint.findById(routePoint.id)).toBeFalsy();
    });
 });

--- a/server/src/spec/models/route.spec.ts
+++ b/server/src/spec/models/route.spec.ts
@@ -1,21 +1,14 @@
-import { Op } from "sequelize";
 import { Route } from "../../main/models";
-import { RouteAttributes, RouteInstance } from "../../main/models/route";
+import { RouteInstance } from "../../main/models/route";
 import { SpecUtil } from "../SpecUtil";
 import { Testbed } from "../Testbed";
 
 describe("The Route model", (): void => {
-   it("can be created and destroyed", (done: DoneFn): void => {
-      let route: RouteInstance;
+   it("can be created and destroyed", async () => {
+      const route: RouteInstance = await Testbed.createRoute();
+      SpecUtil.verifyInstance(route, Testbed.lastAttributes);
+      await route.destroy();
 
-      Testbed.createRoute().then((result: RouteInstance): Promise<void> => {
-         SpecUtil.verifyInstance(result, Testbed.lastAttributes);
-         route = result;
-         return result.destroy();
-      }).then((): Promise<RouteInstance> => {
-         return Route.findById(route.id);
-      }).then((result: RouteInstance): void => {
-         expect(result).toBeFalsy();
-      }).then(done).catch(done);
+      expect(await Route.findById(route.id)).toBeFalsy();
    });
 });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
    "compilerOptions": {
       /* Basic Options */
-      "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+      "target": "es2015", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
       "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
       // "lib": [],                             /* Specify library files to be included in the compilation:  */
       "allowJs": false, /* Allow javascript files to be compiled. */


### PR DESCRIPTION
The 'The Station model does not allow duplicate station numbers' unit test used to fail because of a failing promise (that was expected to fail). Because the promise was very hard to deal with, instead of that I updated the ES version to ES2015 and used async/await to simplify the test.

Unfortunately this also led to the Bluebird Promise being incompatible with the native Promise, which then led to changes to other places. Actually, `Promise.resolve` does the trick just fine, but I found that out after I had already changed many functions to async ones.

NOTE: The cost of the readability of async functions is that they are somewhat slower. Then again, promises themselves are 2-4 times slower than callbacks.